### PR TITLE
IntroGatewayAPI: Fix parentRefs indentation

### DIFF
--- a/docs/blogs/IntroGatewayAPI/GettingCreative.md
+++ b/docs/blogs/IntroGatewayAPI/GettingCreative.md
@@ -23,9 +23,9 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 ...
 spec:
-parentRefs:
-- name: gateway
-  namespace: demo-gateway
+  parentRefs:
+  - name: gateway
+    namespace: demo-gateway
   hostnames: ["http.<DOMAIN_NAME>"] #[2]
 ```
 [1]: Specify a wildcard with your new domain name.\

--- a/docs/blogs/IntroGatewayAPI/GettingStarted.md
+++ b/docs/blogs/IntroGatewayAPI/GettingStarted.md
@@ -114,7 +114,7 @@ metadata:
   name: http
   namespace: demo-app
 spec:
-parentRefs:
+  parentRefs:
   - name: gateway
     namespace: demo-gateway
   hostnames: ["http.example.com"]


### PR DESCRIPTION
Fix indentation of `parentRefs` in example yaml.

The current examples have some indentation errors that cause `oc apply` to fail with the following error message:

    error: error parsing STDIN: error converting YAML to JSON: yaml: line 9: did not find expected '-' indicator

This PR fixes these errors.

* `docs/blogs/IntroGatewayAPI/GettingCreative.md`:
* `docs/blogs/IntroGatewayAPI/GettingStarted.md`: Indent `parentRefs` correctly.