### PR TITLE
feat(nid): Add NID team docs and bug-scrub wrapper for bug-triage plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "network-edge-tools",
+  "owner": {
+    "name": "openshift"
+  },
+  "plugins": [
+    {
+      "name": "nid",
+      "source": "./plugins/nid",
+      "description": "NID (Network Ingress & DNS) team tools for bug triage, diagnostics, and workflow automation"
+    }
+  ]
+}

--- a/plugins/nid/.claude-plugin/plugin.json
+++ b/plugins/nid/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "nid",
+  "description": "NID (Network Ingress & DNS) team tools for bug triage, diagnostics, and workflow automation",
+  "version": "0.1.0",
+  "author": {
+    "name": "github.com/openshift/network-edge-tools"
+  }
+}

--- a/plugins/nid/README.md
+++ b/plugins/nid/README.md
@@ -1,0 +1,29 @@
+# NID Plugin
+
+Tools for the Network Ingress & DNS (NID) team to automate bug triage and diagnostics.
+
+## Commands
+
+- **`/nid:bug-scrub`** — Analyze untriaged OCPBUGS and post AI triage comments directly on each issue before bug scrub meetings.
+
+## Installation
+
+### From ai-helpers marketplace (once upstreamed)
+
+```bash
+/plugin marketplace add openshift/network-edge-tools
+/plugin install nid@network-edge-tools
+```
+
+### Manual
+
+```bash
+git clone git@github.com:openshift/network-edge-tools.git
+# Add plugins/nid to your Claude Code commands path
+```
+
+## Components
+
+The NID team owns these Jira components in the OCPBUGS project:
+- `Networking / router` — HAProxy router, cluster-ingress-operator, Gateway API, route-controller-manager
+- `Networking / DNS` — CoreDNS, dns-operator, DNS resolution

--- a/plugins/nid/commands/bug-scrub.md
+++ b/plugins/nid/commands/bug-scrub.md
@@ -1,0 +1,104 @@
+---
+description: Analyze untriaged NID bugs in OCPBUGS and post AI triage comments directly on each issue before bug scrub meetings
+argument-hint: "[--since last-week] [--issue OCPBUGS-XXXXX] [--dry-run]"
+---
+
+## Name
+nid:bug-scrub
+
+## Synopsis
+```
+/nid:bug-scrub [--since last-week] [--issue OCPBUGS-XXXXX] [--dry-run]
+```
+
+## Description
+The `nid:bug-scrub` command prepares the NID (Network Ingress & DNS) team for bug scrub meetings by analyzing untriaged bugs and posting structured triage comments **directly on each Jira issue**. Instead of generating a separate document, the analysis lives where the team will see it -- on the bug itself.
+
+This is a thin wrapper around `/bug-triage:scrub` (from the `bug-triage` plugin in ai-helpers) with NID team configuration pre-filled.
+
+Run this before your standing bug scrub meeting. When someone opens a bug during the meeting, the AI triage comment is already there with routing checks, importance signals, duplicate candidates, and a recommended action.
+
+## Implementation
+
+This command delegates to `/bug-triage:scrub` with NID-specific arguments pre-filled:
+
+```
+/bug-triage:scrub --team "Network Ingress and DNS" --team-docs plugins/nid/team-docs [--since {since}] [--issue {issue}] [--dry-run]
+```
+
+1. **Resolve team-docs path**: The `--team-docs` path is relative to the network-edge-tools repo root. Resolve it to an absolute path before passing to `/bug-triage:scrub`.
+
+2. **Forward arguments**: Pass through all user-provided arguments (`--since`, `--issue`, `--dry-run`) unchanged.
+
+3. **Execute**: Run the general `/bug-triage:scrub` command which handles:
+   - Team lookup from `team_component_map.json` (components: "Networking / router", "Networking / DNS")
+   - Loading NID team docs (sub-areas, routing guide) from `plugins/nid/team-docs/`
+   - Full triage analysis per the `bug-triage` plugin's SKILL.md
+   - Comment posting with `nid-ai-triaged` label for idempotency
+
+### Prerequisites
+
+- The `bug-triage` plugin from ai-helpers must be installed: `/plugin install bug-triage@ai-helpers`
+- `jira` CLI must be installed and authenticated
+- OCPBUGS project access (view, comment, edit labels)
+
+### Team Docs
+
+NID-specific documentation is in `plugins/nid/team-docs/`:
+
+| File | Purpose |
+|------|---------|
+| `sub-areas.md` | NID sub-area taxonomy (Router/HAProxy, CIO, CoreDNS, ExternalDNS, Gateway API, Route Controller Manager) |
+| `routing-guide.md` | Keywords for detecting bugs misrouted to NID (OVN/SDN, MetalLB, Service Mesh, etc.) |
+| `context/` | Optional: FAQs, AGENTS.md copies, additional context docs |
+
+## Return Value
+- **Per-issue**: A structured triage comment posted directly on each Jira issue
+- **Terminal**: Summary of all bugs analyzed with counts by category
+- **Labels**: `nid-ai-triaged` added to each processed issue
+
+## Examples
+
+1. **Triage a single issue (demo/testing)**:
+   ```
+   /nid:bug-scrub --issue OCPBUGS-83283
+   ```
+
+2. **Dry run on a single issue** (preview comment without posting):
+   ```
+   /nid:bug-scrub --issue OCPBUGS-83283 --dry-run
+   ```
+
+3. **Triage all untriaged bugs from the last week**:
+   ```
+   /nid:bug-scrub --since last-week
+   ```
+
+4. **Triage all untriaged bugs from the last 2 weeks**:
+   ```
+   /nid:bug-scrub --since last-2-weeks
+   ```
+
+5. **Default run** (last week, no dry-run):
+   ```
+   /nid:bug-scrub
+   ```
+
+## Arguments
+
+- **--issue** *(optional)*
+  A specific OCPBUGS issue key to triage. When provided, skips the JQL query and operates on this single issue only. Useful for demos and testing.
+  Example: `--issue OCPBUGS-83283`
+
+- **--since** *(optional)*
+  Time window for querying untriaged bugs.
+  Options: `last-week` (default) | `last-2-weeks` | `last-month` | `YYYY-MM-DD`
+  Example: `--since last-2-weeks`
+
+- **--dry-run** *(optional)*
+  Preview triage comments in the terminal without posting them to Jira or adding labels. Use this to review output before enabling live posting.
+
+## See Also
+- `plugins/nid/team-docs/` -- NID-specific team documentation for triage
+- `/bug-triage:scrub` -- General bug triage command (ai-helpers)
+- `/jira:grooming` -- Generic Jira grooming agenda generator

--- a/plugins/nid/commands/bug-scrub.md
+++ b/plugins/nid/commands/bug-scrub.md
@@ -23,10 +23,10 @@ Run this before your standing bug scrub meeting. When someone opens a bug during
 This command delegates to `/bug-triage:scrub` with NID-specific arguments pre-filled:
 
 ```
-/bug-triage:scrub --team "Network Ingress and DNS" --team-docs plugins/nid/team-docs [--since {since}] [--issue {issue}] [--dry-run]
+/bug-triage:scrub --team "Network Ingress and DNS" --team-docs /absolute/path/to/network-edge-tools/plugins/nid/team-docs [--since {since}] [--issue {issue}] [--dry-run]
 ```
 
-1. **Resolve team-docs path**: The `--team-docs` path is relative to the network-edge-tools repo root. Resolve it to an absolute path before passing to `/bug-triage:scrub`.
+1. **Resolve team-docs path**: Determine the absolute path to `plugins/nid/team-docs/` within this repo (e.g., `~/network-edge-tools/plugins/nid/team-docs`). Always pass an absolute path to `/bug-triage:scrub`.
 
 2. **Forward arguments**: Pass through all user-provided arguments (`--since`, `--issue`, `--dry-run`) unchanged.
 

--- a/plugins/nid/team-docs/routing-guide.md
+++ b/plugins/nid/team-docs/routing-guide.md
@@ -1,0 +1,19 @@
+# Bugs That Don't Belong to NID
+
+When triaging OCPBUGS issues, scan for keywords that indicate the bug was misrouted to NID (Network Ingress & DNS) when it actually belongs to a different networking sub-team.
+
+## OVN / SDN
+Keywords: ovn, ovs, sdn, networkpolicy, egressip, egressfirewall, egressnetworkpolicy, multus, whereabouts, macvlan, ipvlan, ovn-kubernetes, ovnkube, ovs-configuration, br-ex, br-int, geneve, hybrid overlay, ipsec
+Suggested component: Networking / ovn-kubernetes
+
+## Load Balancer / Cloud
+Keywords: metallb, load balancer type, cloud-provider, CCM, cloud controller, cloud-controller-manager, keepalived, IPVS, speaker, frr, bgp peer
+Suggested component: Networking / metal or Cloud Compute / CCM
+
+## Service Mesh
+Keywords: istio sidecar, service mesh, envoy proxy, ossm, maistra, kiali, jaeger tracing, service mesh control plane
+Suggested component: Networking / service-mesh
+
+## Other Networking
+Keywords: kuryr, calico, cilium, nmstate, nodeNetworkConfigurationPolicy, nncp, sriov, sr-iov, dpdk, network-metrics-daemon
+Suggested component: Networking / {matched-area} (e.g., Networking / sriov, Networking / kubernetes-nmstate)

--- a/plugins/nid/team-docs/sub-areas.md
+++ b/plugins/nid/team-docs/sub-areas.md
@@ -1,0 +1,26 @@
+# NID Sub-Area Taxonomy
+
+## Router / HAProxy
+The HAProxy-based router handles all ingress traffic in OpenShift. Issues in this area involve haproxy configuration, reload behavior, route annotations, route certificates, backend health checks, connection handling (408s, 503s), sticky sessions, and TLS termination modes (reencrypt, edge, passthrough). Key terms: router, haproxy, reload, backend, ingress controller, template, 503, 408, connection refused, health check, route annotation, route certificate, route shard, haproxy.config, haproxy template, router pod, router metrics, router canary, sticky session, reencrypt, edge route, passthrough.
+
+## Cluster Ingress Operator (CIO)
+The operator that manages IngressController custom resources. Issues here involve the ingresscontroller CR lifecycle, canary checks, default certificates, wildcard policies, route admission, publish strategies, and endpoint publishing. Key terms: ingress operator, ingresscontroller CR, ingresscontroller, canary, default certificate, wildcard policy, route admission, ingress controller operator, CIO, cluster-ingress-operator, admission policy, domain, publish strategy, endpointpublishingstrategy, ingresscontroller status.
+
+## CoreDNS / DNS Operator
+DNS resolution in the cluster. Issues involve CoreDNS configuration, dns resolution failures, nxdomain errors, custom forwarding rules, stub domains, and dns operator reconciliation. Key terms: coredns, dns, nxdomain, resolve, corefile, dns operator, cluster dns, forward plugin, stub domain, dns resolution, dns-default, bufsize, protobuf, cluster-dns-operator, node resolver, dns pods, dns daemonset.
+
+## ExternalDNS
+Manages DNS records for Route and Ingress resources using cloud provider APIs. Issues involve configuring external DNS providers, zone management, and record lifecycle. Key terms: external-dns, externaldns, dns provider, zone, infoblox, route53, azure dns, google dns, external-dns-operator, dns record, txtrecord, cname, dnsendpoint.
+
+## Gateway API
+Kubernetes Gateway API implementation for OpenShift. Issues involve Gateway, HTTPRoute, GRPCRoute, and related resources. Key terms: gateway, gatewayclass, httproute, grpcroute, referencegrant, gateway-api, istio gateway, gateway controller, tcproute, tlsroute, backendref, parentref, gateway listener, gateway status.
+
+## Route Controller Manager
+Manages route status updates and ingress-to-route conversion. Key terms: route-controller-manager, route status, admitted, ingress to route, route admission check, route controller, openshift-route-controller-manager.
+
+## Non-functional Categories
+If the issue is not about a functional problem in any sub-area above, classify as:
+- **Documentation** -- AGENTS.md, README, docs, enhancement proposals, conventions
+- **CI / Infrastructure** -- test infrastructure, prow jobs, CI config, Dockerfiles, build scripts
+- **Tooling** -- developer tooling, scripts, automation, MCP server, plugins
+- **Dependency Management** -- go.mod bumps, image updates, ART reconciliation


### PR DESCRIPTION
## Summary

- Adds NID-specific team documentation for the general `bug-triage` plugin ([openshift-eng/ai-helpers#420](https://github.com/openshift-eng/ai-helpers/pull/420))
- Adds a thin `/nid:bug-scrub` wrapper command that delegates to `/bug-triage:scrub` with NID team config pre-filled
- Adds ai-helpers plugin structure (plugin.json, marketplace.json) for the NID plugin

### Depends on

This PR depends on [openshift-eng/ai-helpers#420](https://github.com/openshift-eng/ai-helpers/pull/420) which adds the general `bug-triage` plugin to ai-helpers. The wrapper command (`/nid:bug-scrub`) calls `/bug-triage:scrub` from that plugin.

### Files added

| File | Purpose |
|------|---------|
| `plugins/nid/team-docs/sub-areas.md` | NID sub-area taxonomy (Router/HAProxy, CIO, CoreDNS, ExternalDNS, Gateway API, Route Controller Manager) with semantic descriptions |
| `plugins/nid/team-docs/routing-guide.md` | Non-NID keyword groups (OVN/SDN, MetalLB, Service Mesh) for misrouting detection |
| `plugins/nid/commands/bug-scrub.md` | Thin wrapper: `/nid:bug-scrub` → `/bug-triage:scrub --team "Network Ingress and DNS" --team-docs ...` |
| `plugins/nid/.claude-plugin/plugin.json` | Plugin metadata (v0.1.0) |
| `.claude-plugin/marketplace.json` | Repo-level marketplace registration |
| `plugins/nid/README.md` | Plugin documentation |

### How it works

Teams provide domain knowledge as documentation files. The general `bug-triage` plugin reads these at runtime:
- `sub-areas.md` — the AI uses prose descriptions to semantically classify bugs into NID sub-areas
- `routing-guide.md` — keyword groups for detecting bugs misrouted to NID

Usage:
```
/nid:bug-scrub --since last-week
/nid:bug-scrub --issue OCPBUGS-83283 --dry-run
```

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.

Assisted with Claude